### PR TITLE
Fix: "warning: 'esphome::select::Select::state' is deprecated: Use current_option() instead of .state. Will be removed in 2026.7.0"

### DIFF
--- a/switchbot-plug-mini-w2001401-homekit-enabled-ja.yaml
+++ b/switchbot-plug-mini-w2001401-homekit-enabled-ja.yaml
@@ -330,9 +330,9 @@ switch:
       - light.turn_on:
           id: white_led
           brightness: !lambda |-
-            if (id(led_brightness).state == "明るい") {
+            if (id(led_brightness).current_option() == "明るい") {
               return 1; // LEDライトの明るさ設定が「明るい」に設定されているときは、白色LEDを100%の明るさで点灯させる
-            } else if (id(led_brightness).state == "暗い") {
+            } else if (id(led_brightness).current_option() == "暗い") {
               return 0.5; // LEDライトの明るさ設定が「暗い」に設定されているときは、白色LEDを50%の明るさで点灯させる
             } else {
               return 0; // LEDライトの明るさ設定が上記以外（LEDオフ）に設定されているときは、白色LEDを0%の明るさで点灯させる（消灯させる）

--- a/switchbot-plug-mini-w2001401-homekit-enabled.yaml
+++ b/switchbot-plug-mini-w2001401-homekit-enabled.yaml
@@ -334,9 +334,9 @@ switch:
       - light.turn_on:
           id: white_led
           brightness: !lambda |-
-            if (id(led_brightness).state == "Bright") {
+            if (id(led_brightness).current_option() == "Bright") {
               return 1; // When the brightness setting of the LED light is set to “Bright”, the White LED is turned on at 100% brightness
-            } else if (id(led_brightness).state == "Dim") {
+            } else if (id(led_brightness).current_option() == "Dim") {
               return 0.5; // When the brightness setting of the LED light is set to “Dim”, the White LED is turned on at 50% brightness.
             } else {
               return 0; // When the brightness setting of the LED light is set to other than the above (LED Off), the White LED is turned on at 0% brightness (turned off)

--- a/switchbot-plug-mini-w2001401-ja.yaml
+++ b/switchbot-plug-mini-w2001401-ja.yaml
@@ -278,9 +278,9 @@ switch:
       - light.turn_on:
           id: white_led
           brightness: !lambda |-
-            if (id(led_brightness).state == "明るい") {
+            if (id(led_brightness).current_option() == "明るい") {
               return 1; // LEDライトの明るさ設定が「明るい」に設定されているときは、白色LEDを100%の明るさで点灯させる
-            } else if (id(led_brightness).state == "暗い") {
+            } else if (id(led_brightness).current_option() == "暗い") {
               return 0.5; // LEDライトの明るさ設定が「暗い」に設定されているときは、白色LEDを50%の明るさで点灯させる
             } else {
               return 0; // LEDライトの明るさ設定が上記以外（LEDオフ）に設定されているときは、白色LEDを0%の明るさで点灯させる（消灯させる）

--- a/switchbot-plug-mini-w2001401.yaml
+++ b/switchbot-plug-mini-w2001401.yaml
@@ -281,9 +281,9 @@ switch:
       - light.turn_on:
           id: white_led
           brightness: !lambda |-
-            if (id(led_brightness).state == "Bright") {
+            if (id(led_brightness).current_option() == "Bright") {
               return 1; // When the brightness setting of the LED light is set to “Bright”, the White LED is turned on at 100% brightness
-            } else if (id(led_brightness).state == "Dim") {
+            } else if (id(led_brightness).current_option() == "Dim") {
               return 0.5; // When the brightness setting of the LED light is set to “Dim”, the White LED is turned on at 50% brightness.
             } else {
               return 0; // When the brightness setting of the LED light is set to other than the above (LED Off), the White LED is turned on at 0% brightness (turned off)


### PR DESCRIPTION
Small change that replaces "state" with "current_option()" in the Plug > on_turn_on > white_led > brightness lambda.


<img width="836" height="466" alt="image" src="https://github.com/user-attachments/assets/eee098f3-3432-492c-920a-ca0a08a996ed" />
